### PR TITLE
Prediction

### DIFF
--- a/quantization/__init__.py
+++ b/quantization/__init__.py
@@ -1,3 +1,4 @@
 from quantization import Quantizer
 from quantization import QuantizerTrainer
 from quantization import read_hdf5_data
+from prediction import JointCodebookPredictor

--- a/quantization/prediction.py
+++ b/quantization/prediction.py
@@ -1,0 +1,124 @@
+import torch
+from torch import nn
+from torch import Tensor
+from typing import Tuple
+
+
+
+class JointCodebookPredictor(nn.Module):
+    """
+    This module predicts a group of codebook indexes from a vector.  The idea is that
+    you have a number of codebooks (probably jointly trained), from class Quantizer,
+    and you want to predict the probabilities of the codebook entries based on some
+    predictor that you are training.
+
+    The simplest thing would be to project the vector using nn.Linear, then
+    reshape and use logsoftmax to normalize the probabilities within each group,
+    then compute the likelihood.  However, this has a constraint that all the
+    codebooks are predicted independently of each other.  This module allows you
+    to predict them jointly, by regressing each codebook on all previous codebooks.
+    This is done with a nonlinearity in which the previous codebook entries are combined
+    with the input predictor vector, so that the regression is not purely
+    linear.
+
+    Args:
+        predictor_dim: the number of features that we use to predict the codebook
+               indexes, e.g. 2048 (will depend on your model).
+        num_codebooks: the number of codebooks that you are predicting;
+               will likely be the same as the bytes_per_frame given to the
+               QuantizerTrainer that you used to train the Quantizer you
+               are predicting.
+    """
+    def __init__(self,
+                 predictor_dim: int,
+                 num_codebooks: int,
+                 codebook_size: int = 256,
+                 hidden_dim: int = 256):
+        super(JointCodebookPredictor, self).__init__()
+
+        self.num_codebooks = num_codebooks
+        self.codebook_size = codebook_size
+
+        self.linear1 = nn.Linear(predictor_dim, num_codebooks * hidden_dim)
+
+
+        linear_self_out_dim = (num_codebooks - 1) * hidden_dim
+        linear_self_in_dim = (num_codebooks - 1) * codebook_size
+        self.linear_self = nn.Parameter(torch.randn(linear_self_out_dim,
+                                                    linear_self_in_dim) * (linear_self_in_dim ** -0.5))
+
+        # num_codebooks == 3 and hidden_dim == 2 and codebook_size == 2,
+        # the expression below has the value:
+        #tensor([[ True,  True, False, False],
+        #        [ True,  True, False, False],
+        #        [ True,  True,  True,  True],
+        #        [ True,  True,  True,  True]])
+        self.register_buffer('linear_self_mask',
+                             ((torch.arange(linear_self_out_dim) // hidden_dim).unsqueeze(1) >=
+                              (torch.arange(linear_self_in_dim) // codebook_size).unsqueeze(0)))
+
+        print("linear_self_mask = ", self.linear_self_mask) # TEMP
+
+        self.linear2 = nn.Linear(num_codebooks * hidden_dim,
+                                 num_codebooks * codebook_size)
+
+
+    def forward(self,
+                predictor: Tensor,
+                codebook_indexes: Tensor) -> Tuple[Tensor, Tensor]:
+        """
+        Forward function.
+
+        Args:
+          predictor: a Tensor of some real type, with shape (*, predictor_dim).
+          codebook_indexes:  a Tensor of integers, of shape (*, num_codebooks),
+             where the '*' should be the same as for `predictor`.  It will be
+             converted to type torch.int64.  Should contain indexes of codebook
+             entries, in {0..codebook_size-1},
+             or negative values which will be interpreted as "no codebook index here"
+             (e.g. due to padding); we assume that each frame will either have
+             all-negative or all-nonnegative indexes, meaning that (codebook_indexes >= 0)
+             should not vary as you change the last index into it.
+
+        Returns: total_logprob, total_count, where:
+           total_logprob: a scalar Tensor, containing the total log-probability of all
+                  the nonnegative codebook indexes,
+           total_count: a scalar Tensor containing the total count of nonzero frames,
+                  satisfying total_count <= codebook_indexes.numel() / num_groups
+        """
+        codebook_indexes = codebook_indexes.to(torch.int64)
+        assert list(predictor.shape[:-1]) == list(codebook_indexes.shape[:-1])
+        assert codebook_indexes.shape[-1] == self.num_codebooks
+
+        tot_codebook_dim = self.num_codebooks * self.codebook_size
+
+        common_shape = list(predictor.shape[:-1])
+        codebook_one_hot = torch.zeros(*common_shape, tot_codebook_dim,
+                                       device=predictor.device)
+
+        codebook_mask = (codebook_indexes >= 0)
+        codebook_indexes_floor = torch.clamp(codebook_indexes, min=0)
+        codebook_one_hot.scatter_(dim=-1, index=codebook_indexes_floor,
+                                  src=codebook_mask.to(torch.float32))
+
+        codebook_one_hot_part = torch.narrow(codebook_one_hot, -1, 0,
+                                             tot_codebook_dim - self.codebook_size)
+        self_predictor = torch.matmul(codebook_one_hot_part,
+                                      (self.linear_self * self.linear_self_mask).transpose(0, 1))
+        hidden = self.linear1(predictor)
+        # Before the hidden layer, add the 'self_predictor' term to all but the 1st
+        # block of "hidden".
+        hidden_part = torch.narrow(hidden, -1, self.codebook_size,
+                                   tot_codebook_dim - self.codebook_size)
+        hidden_part += self_predictor
+
+        hidden = nn.functional.relu(hidden)
+        logprobs = self.linear2(hidden)
+        logprobs = logprobs.reshape(*common_shape, self.num_codebooks, self.codebook_size)
+        logprobs = logprobs.log_softmax(dim=-1)
+        logprobs = logprobs.reshape(*common_shape, self.num_codebooks * self.codebook_size)
+
+        tot_logprob = torch.dot(logprobs.reshape(-1), codebook_one_hot.reshape(-1))
+        tot_count = codebook_mask.sum()
+
+        return (tot_logprob, tot_count)

--- a/quantization/prediction.py
+++ b/quantization/prediction.py
@@ -59,6 +59,8 @@ class JointCodebookPredictor(nn.Module):
 
         print("linear_self_mask = ", self.linear_self_mask) # TEMP
 
+
+        self.norm = nn.LayerNorm(num_codebooks * codebook_size)
         self.linear2 = nn.Linear(num_codebooks * hidden_dim,
                                  num_codebooks * codebook_size)
 
@@ -112,8 +114,12 @@ class JointCodebookPredictor(nn.Module):
                                    tot_codebook_dim - self.codebook_size)
         hidden_part += self_predictor
 
-        hidden = nn.functional.relu(hidden)
+        hidden = self.norm(nn.functional.relu(hidden))
+
         logprobs = self.linear2(hidden)
+
+
+
         logprobs = logprobs.reshape(*common_shape, self.num_codebooks, self.codebook_size)
         logprobs = logprobs.log_softmax(dim=-1)
         logprobs = logprobs.reshape(*common_shape, self.num_codebooks * self.codebook_size)

--- a/quantization/test_train_hdf5.py
+++ b/quantization/test_train_hdf5.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 from torch import Tensor
 from quantization import read_hdf5_data, Quantizer, QuantizerTrainer
-
+from prediction import JointCodebookPredictor
 
 def _test_train_from_file():
     train, valid = read_hdf5_data('training_data.hdf5')
@@ -76,6 +76,60 @@ def _test_train_from_file():
           f"it means that the data is easier to compress than if it\n"
           f"were a Gaussian with a spherical covariance matrix.")
 
+def _test_joint_predictor():
+    train, valid = read_hdf5_data('training_data.hdf5')
+    dim = train.shape[1]
+
+    device = torch.device('cuda')
+    quantizer_fn = 'quantizer.pt'
+    quantizer = Quantizer(dim=dim, num_codebooks=4, codebook_size=256)
+    quantizer.load_state_dict(torch.load(quantizer_fn))
+    quantizer = quantizer.to(device)
+
+    # bytes_per_frame is the key thing you might want to tune: e.g. try 2 or 8
+    # or 16.
+    bytes_per_frame = 4
+
+    B = 512  # Minibatch size, this is very arbitrary, it's close to what we used
+             # when we tuned this method.
+    def minibatch_generator(data: Tensor,
+                            repeat: bool):
+        assert 3 * B < data.shape[0]
+        cur_offset = 0
+        while (True if repeat else cur_offset + B <= data.shape[0]):
+            start = cur_offset % (data.shape[0] + 1 - B)
+            end = start + B
+            cur_offset += B
+            yield data[start:end,:].to(device).to(dtype=torch.float)
+
+    predictor = JointCodebookPredictor(predictor_dim=dim,
+                                       num_codebooks=bytes_per_frame).to(device)
+
+    optim = torch.optim.Adam(
+        predictor.parameters(), lr=0.0001, betas=(0.9, 0.98), eps=1e-9, weight_decay=1.0e-06
+    )
+    scheduler = torch.optim.lr_scheduler.StepLR(optim,
+                                                step_size=2000,
+                                                gamma=0.5)
+
+    count = 0
+    for x in minibatch_generator(train, repeat=True):
+        x = x.to(device)
+        encoding = quantizer.encode(x)
+        tot_logprob, tot_count = predictor(x, encoding) # should be easy to predict encoding from x.
+
+        loss = -(tot_logprob / tot_count)
+        if count % 200 == 0:
+            logging.info(f"Iter={count}, loss = {loss.item():.3f}")
+        loss.backward()
+        optim.step()
+        scheduler.step()
+        count += 1
+        if count > 10000:
+            break
+
+
 if __name__ == "__main__":
     logging.getLogger().setLevel(logging.INFO)
-    _test_train_from_file()
+    #_test_train_from_file()
+    _test_joint_predictor()

--- a/quantization/test_train_hdf5.py
+++ b/quantization/test_train_hdf5.py
@@ -126,6 +126,7 @@ def _test_joint_predictor():
             logging.info(f"Iter={count}, loss = {loss.item():.3f}")
         loss.backward()
         optim.step()
+        optim.zero_grad()
         scheduler.step()
         count += 1
         if count > 10000:
@@ -134,5 +135,5 @@ def _test_joint_predictor():
 
 if __name__ == "__main__":
     logging.getLogger().setLevel(logging.INFO)
-    #_test_train_from_file()
+    _test_train_from_file()
     _test_joint_predictor()

--- a/quantization/test_train_hdf5.py
+++ b/quantization/test_train_hdf5.py
@@ -103,7 +103,8 @@ def _test_joint_predictor():
             yield data[start:end,:].to(device).to(dtype=torch.float)
 
     predictor = JointCodebookPredictor(predictor_dim=dim,
-                                       num_codebooks=bytes_per_frame).to(device)
+                                       num_codebooks=bytes_per_frame,
+                                       self_prediction=True).to(device)
 
     optim = torch.optim.Adam(
         predictor.parameters(), lr=0.0001, betas=(0.9, 0.98), eps=1e-9, weight_decay=1.0e-06

--- a/quantization/test_train_hdf5.py
+++ b/quantization/test_train_hdf5.py
@@ -113,9 +113,11 @@ def _test_joint_predictor():
                                                 gamma=0.5)
 
     count = 0
+
+    x_noise_level = 0.0
     for x in minibatch_generator(train, repeat=True):
         x = x.to(device)
-        encoding = quantizer.encode(x)
+        encoding = quantizer.encode(x + x_noise_level * torch.randn_like(x))
         tot_logprob, tot_count = predictor(x, encoding) # should be easy to predict encoding from x.
 
         loss = -(tot_logprob / tot_count)


### PR DESCRIPTION
This branch adds a module which is a convenient way to predict these codebook entries, regressing on something.
(In the test code, we regress on the vector itself, that we encoded, but in general it would be something else that
we are trying to learn).

This supports also regressing on previous codebook entries in the list of codebooks, so in effect it is jointly 
predicting the whole set of codebook entries, rather than modeling them independently.  We may find that this
improves results.